### PR TITLE
`onHWKeyPressed` adjustment of event handler type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 declare module "react-native-hw-keyboard-event";
 
-export function onHWKeyPressed(hwKeyEvent: { pressedKey: string }): void;
+type keyboardEventHandler = (evt: { pressedKey: string }) => void
+
+export function onHWKeyPressed(hwKeyEvent: keyboardEventHandler): void;
 export function removeOnHWKeyPressed(): void;


### PR DESCRIPTION
currently `onHWKeyPressed` receives an object instead of an event handler, I've updated the types based on the automated ts errors presented by the current type declaration